### PR TITLE
Update Python template

### DIFF
--- a/code-samples/python/_template_with_license.py
+++ b/code-samples/python/_template_with_license.py
@@ -1,3 +1,14 @@
+"""One-line summary of your script.
+
+Multi-line description of your script (make sure you include the copyright and
+license notice).
+
+Script Dependencies:
+    requests
+
+Depencency Installation:
+    $ pip install requests
+
 Copyright (c) 2017, Cisco Systems, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -17,16 +28,29 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+"""
 
-# standard library imports
+
+# Standard library imports
+import json
+
+# Third-party imports
 import requests
 
-# Define the API server root as a variable
-url = 'http://server:8081/api/v0/host'
+# Local application/library-specific imports
 
-# Define variable to store the results of a request
-response = requests.get(url)
 
-# Output the JSON text of the reponse
-print response.text
+# Define the API server root as a CONSTANT
+URL = 'http://server:8081/api/v0/host'
 
+# Define a variable to store the response to the request
+response = requests.get(URL)
+
+# Verify that the request was successful
+response.raise_for_status()
+
+# Parse the JSON data
+json_data = response.json()
+
+# Print the JSON data using a "pretty print" format
+print(json.dumps(json_data, indent=4))


### PR DESCRIPTION
Header text in a Python file should be contained within a Python docstring (the unquoted text will return an error).

The requests module is a  third-party import.

The header text should probably list required third-party packages for the script to function - unless these are documented elsewhere in the code (like a requirements.txt file or a Pipfile, etc.).

Constants (Python variables that should not change throughout the script's execution should be in ALL CAPS).

It should be standard practice to performa a simple response code check to verify if the request succeeded or not.  This helps provide more accurate and useful errors to the users when a response fails.  Without it, they don't get an error until they try access, parse or use the data.

It should also be a standard practice to parse the data once we have verified that the request was successful.

Unformatted JSON output can be scarry, formatted JSON is a little less scarry.  :100: